### PR TITLE
Load all YAMLs in a directory if a path to the directory is given as ruleset-path

### DIFF
--- a/src/cli/subcommand/check.rs
+++ b/src/cli/subcommand/check.rs
@@ -55,18 +55,22 @@ pub fn run(opts: CheckOpts) -> i32 {
 
 pub(crate) fn handle_opts(opts: CheckOpts) -> Result<usize> {
     let mut rule_map = HashMap::<ruleset::Language, Vec<Rule>>::new();
-    let ruleset = ruleset::from_reader(&opts.ruleset_path).map_err(|e| {
+
+    let rulesets = ruleset::from_path(&opts.ruleset_path).map_err(|e| {
         anyhow!(
             "failed to load ruleset file {}: {}",
             opts.ruleset_path.as_os_str().to_string_lossy(),
             e
         )
     })?;
-    for rule in ruleset.rules {
-        if let Some(v) = rule_map.get_mut(&rule.language) {
-            v.push(rule);
-        } else {
-            rule_map.insert(rule.language, vec![rule]);
+
+    for ruleset in rulesets {
+        for rule in ruleset.rules {
+            if let Some(v) = rule_map.get_mut(&rule.language) {
+                v.push(rule);
+            } else {
+                rule_map.insert(rule.language, vec![rule]);
+            }
         }
     }
 


### PR DESCRIPTION
# Description

This PR changes the way to load rulesets following `ruleset-path` cli opt. Now users can use multiple rulesets with a single command as follows:

```
shisho check <ruleset-dir> <src-dir>
```
# Checklist

- [x] I opened a draft PR or added the `[WIP]` to the title if my PR is not ready for review.
- [x] I have reviewed the code by myself.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests enough to show how your code behaves and that your code works as expected.

# Additional Notes

N/A