### PR TITLE
refactor: Prevent `RootNode` generation as much as possible

### DIFF
--- a/src/cli/reporter/console.rs
+++ b/src/cli/reporter/console.rs
@@ -1,7 +1,9 @@
+use std::convert::TryFrom;
+
 use super::Reporter;
 use crate::core::{
-    language::Queryable, matcher::MatchedItem, node::Range, ruleset::Rule, source::Code,
-    target::Target, transform::Transformable,
+    language::Queryable, matcher::MatchedItem, node::Range, pattern::Pattern, ruleset::Rule,
+    source::Code, target::Target, transform::Transformable,
 };
 use ansi_term::{Color, Style};
 use anyhow::Result;
@@ -87,7 +89,8 @@ impl<'a, W: std::io::Write> Reporter<'a> for ConsoleReporter<'a, W> {
                 }
                 writeln!(self.writer, "Suggested changes ({}):", idx + 1)?;
                 let old_code: Code<T> = target.body.clone().into();
-                let new_code = old_code.transform(&mitem, rewrite.as_str())?;
+                let pattern = Pattern::try_from(rewrite.as_str())?;
+                let new_code = old_code.transform(&mitem, &pattern)?;
 
                 let diff = TextDiff::from_lines(target.body.as_str(), new_code.as_str());
                 for (group_idx, group) in diff.grouped_ops(1).iter().enumerate() {

--- a/src/cli/reporter/json.rs
+++ b/src/cli/reporter/json.rs
@@ -1,7 +1,9 @@
+use std::convert::TryFrom;
+
 use super::Reporter;
 use crate::core::{
-    language::Queryable, matcher::MatchedItem, node::Range, ruleset::Rule, source::Code,
-    target::Target, transform::Transformable,
+    language::Queryable, matcher::MatchedItem, node::Range, pattern::Pattern, ruleset::Rule,
+    source::Code, target::Target, transform::Transformable,
 };
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -56,7 +58,8 @@ impl<'a, W: std::io::Write> Reporter<'a> for JSONReporter<'a, W> {
 
             for rewrite in rule.get_rewrite_options()? {
                 let old_code: Code<T> = target.body.clone().into();
-                let new_code = old_code.transform(&mitem, rewrite.as_str())?;
+                let pattern = Pattern::try_from(rewrite.as_str())?;
+                let new_code = old_code.transform(&mitem, &pattern)?;
 
                 let diff = TextDiff::from_lines(target.body.as_str(), new_code.as_str())
                     .unified_diff()

--- a/src/core/language/docker.rs
+++ b/src/core/language/docker.rs
@@ -51,7 +51,8 @@ mod tests {
     use super::*;
     use crate::core::{
         matcher::MatchedItem,
-        query::{MetavariableId, Query},
+        pattern::Pattern,
+        query::{MetavariableId},
         tree::{Tree, TreeView},
     };
     use std::convert::TryFrom;
@@ -59,7 +60,8 @@ mod tests {
     #[test]
     fn test_from_instruction() {
         {
-            let query = Query::<Dockerfile>::try_from(r#"FROM :[A]"#).unwrap();
+            let query = Pattern::<Dockerfile>::try_from(r#"FROM :[A]"#).unwrap();
+            let query = query.as_query();
             let tree = Tree::<Dockerfile>::try_from(r#"FROM name"#).unwrap();
             let ptree = TreeView::from(&tree);
             let session = ptree.matches(&query);
@@ -73,7 +75,8 @@ mod tests {
         }
 
         {
-            let query = Query::<Dockerfile>::try_from(r#"FROM :[A]::[B]"#).unwrap();
+            let query = Pattern::<Dockerfile>::try_from(r#"FROM :[A]::[B]"#).unwrap();
+            let query = query.as_query();
             let tree = Tree::<Dockerfile>::try_from(r#"FROM name:tag"#).unwrap();
             let ptree = TreeView::from(&tree);
             let session = ptree.matches(&query);
@@ -92,7 +95,8 @@ mod tests {
         }
 
         {
-            let query = Query::<Dockerfile>::try_from(r#"FROM :[A]::[B]@:[HASH]"#).unwrap();
+            let query = Pattern::<Dockerfile>::try_from(r#"FROM :[A]::[B]@:[HASH]"#).unwrap();
+            let query = query.as_query();
             let tree = Tree::<Dockerfile>::try_from(r#"FROM name:tag@hash"#).unwrap();
             let ptree = TreeView::from(&tree);
             let session = ptree.matches(&query);
@@ -117,7 +121,8 @@ mod tests {
 
         {
             let query =
-                Query::<Dockerfile>::try_from(r#"FROM :[A]::[B]@:[HASH] as :[ALIAS]"#).unwrap();
+                Pattern::<Dockerfile>::try_from(r#"FROM :[A]::[B]@:[HASH] as :[ALIAS]"#).unwrap();
+            let query = query.as_query();
             let tree = Tree::<Dockerfile>::try_from(r#"FROM name:tag@hash as alias"#).unwrap();
             let ptree = TreeView::from(&tree);
             let session = ptree.matches(&query);
@@ -149,7 +154,8 @@ mod tests {
     #[test]
     fn test_run_instruction() {
         {
-            let query = Query::<Dockerfile>::try_from(r#"RUN :[X]"#).unwrap();
+            let query = Pattern::<Dockerfile>::try_from(r#"RUN :[X]"#).unwrap();
+            let query = query.as_query();
             let tree =
                 Tree::<Dockerfile>::try_from(r#"RUN echo "hosts: files dns" > /etc/nsswitch.conf"#)
                     .unwrap();
@@ -164,7 +170,8 @@ mod tests {
             );
         }
         {
-            let query = Query::<Dockerfile>::try_from(r#"RUN :[X]"#).unwrap();
+            let query = Pattern::<Dockerfile>::try_from(r#"RUN :[X]"#).unwrap();
+            let query = query.as_query();
             let cmd = r#"RUN apt-get update && apt-get install -y \
             aufs-tools \
             automake \
@@ -185,7 +192,8 @@ mod tests {
     #[test]
     fn test_copy_instruction() {
         {
-            let query = Query::<Dockerfile>::try_from(r#"COPY :[X] :[Y]"#).unwrap();
+            let query = Pattern::<Dockerfile>::try_from(r#"COPY :[X] :[Y]"#).unwrap();
+            let query = query.as_query();
             let tree = Tree::<Dockerfile>::try_from(r#"COPY ./ /app"#).unwrap();
             let ptree = TreeView::from(&tree);
             let session = ptree.matches(&query);

--- a/src/core/language/hcl.rs
+++ b/src/core/language/hcl.rs
@@ -61,6 +61,7 @@ impl Queryable for HCL {
 #[cfg(test)]
 mod tests {
     use crate::core::matcher::MatchedItem;
+    use crate::core::pattern::Pattern;
     use crate::core::query::MetavariableId;
     use crate::core::transform::Transformable;
     use crate::core::tree::{Tree, TreeView};
@@ -129,7 +130,7 @@ mod tests {
     #[test]
     fn test_query_with_simple_metavariable() {
         {
-            let query = Query::<HCL>::try_from(r#"attr = :[X]"#).unwrap();
+            let query = Query::from(&Pattern::<HCL>::try_from(r#"attr = :[X]"#).unwrap());
             let tree = Tree::<HCL>::try_from(
                 r#"resource "rtype" "rname" { 
                 attr = "value"

--- a/src/core/matcher/item.rs
+++ b/src/core/matcher/item.rs
@@ -47,7 +47,10 @@ impl<'tree> MatchedItem<'tree> {
         self.captures.get(id)
     }
 
-    pub fn satisfies_all<T: Queryable>(&self, constraints: &[Constraint<T>]) -> Result<bool> {
+    pub fn satisfies_all<T: Queryable + 'static>(
+        &self,
+        constraints: &[Constraint<T>],
+    ) -> Result<bool> {
         for c in constraints {
             if !self.satisfies(c)? {
                 return Ok(false);
@@ -56,7 +59,7 @@ impl<'tree> MatchedItem<'tree> {
         Ok(true)
     }
 
-    pub fn satisfies<T: Queryable>(&self, constraint: &Constraint<T>) -> Result<bool> {
+    pub fn satisfies<T: Queryable + 'static>(&self, constraint: &Constraint<T>) -> Result<bool> {
         if !self.captures.contains_key(&constraint.target) {
             return Ok(false);
         }
@@ -71,7 +74,7 @@ impl<'tree> MatchedItem<'tree> {
                     )),
                     CaptureItem::Nodes(n) => Ok(n.as_vec().iter().any(|node| {
                         let ptree = TreeView::<T>::from((*node).clone());
-                        !ptree.matches(q).count() == 0
+                        !ptree.matches(&q.into()).count() == 0
                     })),
                 }
             }
@@ -84,7 +87,7 @@ impl<'tree> MatchedItem<'tree> {
                     )),
                     CaptureItem::Nodes(n) => Ok(n.as_vec().iter().all(|node| {
                         let ptree = TreeView::<T>::from((*node).clone());
-                        ptree.matches(q).count() == 0
+                        ptree.matches(&q.into()).count() == 0
                     })),
                 }
             }

--- a/src/core/matcher/tree.rs
+++ b/src/core/matcher/tree.rs
@@ -17,7 +17,7 @@ pub struct TreeMatcher<'tree, 'query, T: Queryable> {
     traverser: TreeTreverser<'tree>,
 
     /// Query
-    query: RootNode<'query>,
+    query: &'query RootNode<'query>,
 
     /// local state for implementing `Iterator`/    
     items: Vec<MatchedItem<'tree>>,
@@ -29,7 +29,7 @@ pub struct TreeMatcher<'tree, 'query, T: Queryable> {
 impl<'tree, 'query, T: Queryable> TreeMatcher<'tree, 'query, T> {
     pub fn new(view: &'tree TreeView<'tree, T>, query: &'query Query<T>) -> Self {
         TreeMatcher {
-            query: query.root_node(),
+            query: &query.root_node,
             traverser: view.traverse(),
             items: vec![],
 

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -103,7 +103,23 @@ impl<'tree> Node<'tree> {
     }
 }
 
+#[derive(Debug)]
 pub struct RootNode<'tree>(Node<'tree>);
+
+impl<'tree> RootNode<'tree> {
+    pub fn from_tstree(tstree: &'tree tree_sitter::Tree, source: &'tree [u8]) -> Self {
+        let tsnode = tstree.root_node();
+        let children: Vec<Node<'tree>> = tsnode
+            .children(&mut tsnode.walk())
+            .map(|c| Node::from_tsnode(c, source))
+            .collect();
+        RootNode::new(Node {
+            inner: tsnode,
+            children,
+            source,
+        })
+    }
+}
 
 impl<'tree> RootNode<'tree> {
     pub fn new(node: Node<'tree>) -> Self {
@@ -112,6 +128,12 @@ impl<'tree> RootNode<'tree> {
 
     pub fn as_node(&self) -> &Node<'tree> {
         &self.0
+    }
+}
+
+impl<'tree> From<RootNode<'tree>> for Node<'tree> {
+    fn from(r: RootNode<'tree>) -> Self {
+        r.0
     }
 }
 

--- a/src/core/pattern.rs
+++ b/src/core/pattern.rs
@@ -1,8 +1,4 @@
-use super::{
-    language::Queryable,
-    node::{Node, RootNode},
-    source::NormalizedSource,
-};
+use super::{language::Queryable, node::RootNode, source::NormalizedSource};
 use anyhow::{anyhow, Result};
 use std::{
     convert::{TryFrom, TryInto},
@@ -24,8 +20,8 @@ impl<T> Pattern<T>
 where
     T: Queryable,
 {
-    pub fn root_node(&'_ self) -> RootNode<'_> {
-        RootNode::new(Node::from_tsnode(self.tstree.root_node(), &self.source))
+    pub fn to_root_node(&'_ self) -> RootNode<'_> {
+        RootNode::from_tstree(&self.tstree, &self.source)
     }
 
     pub fn string_between(&self, start: usize, end: usize) -> Result<String> {

--- a/src/core/ruleset.rs
+++ b/src/core/ruleset.rs
@@ -4,7 +4,8 @@ use std::{convert::TryFrom, fs::File, path::Path, str::FromStr};
 use walkdir::WalkDir;
 
 use crate::core::{
-    constraint::Constraint, language::Queryable, matcher::MatchedItem, query::Query, tree::TreeView,
+    constraint::Constraint, language::Queryable, matcher::MatchedItem, pattern::Pattern,
+    tree::TreeView,
 };
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -78,9 +79,9 @@ impl Rule {
         let patterns = self.get_patterns()?;
         let mut matches = vec![];
         for p in patterns {
-            let query = Query::<T>::try_from(p.as_str())?;
+            let p = Pattern::<T>::try_from(p.as_str())?;
             matches.extend(
-                tree.matches(&query)
+                tree.matches(&p.as_query())
                     .filter(|x| x.satisfies_all(&constraints).unwrap_or(false)),
             );
         }


### PR DESCRIPTION
Signed-off-by: Takashi Yoneuchi <takashi.yoneuchi@shift-js.info>