### PR TITLE
Ignore non YAMLs on ruleset loading

### DIFF
--- a/src/core/language.rs
+++ b/src/core/language.rs
@@ -61,6 +61,6 @@ pub trait Queryable {
     }
 
     fn node_value_eq<'a, 'b>(l: &Node<'a>, r: &Node<'b>) -> bool {
-        l.as_str().to_string() == r.as_str().to_string()
+        *l.as_str() == *r.as_str()
     }
 }

--- a/src/core/matcher/tree.rs
+++ b/src/core/matcher/tree.rs
@@ -254,7 +254,7 @@ where
     type Item = MatchedItem<'tree>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let qnodes: Vec<&Node<'query>> = T::unwrap_root(&self.query)
+        let qnodes: Vec<&Node<'query>> = T::unwrap_root(self.query)
             .iter()
             .filter(|n| !T::is_skippable(n))
             .collect();

--- a/src/core/ruleset.rs
+++ b/src/core/ruleset.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod test;
+
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fs::File, path::Path, str::FromStr};
@@ -190,7 +193,13 @@ pub fn from_path<P: AsRef<Path>>(ruleset_path: P) -> Result<Vec<RuleSet>> {
             .into_iter()
             .filter_map(|e| e.ok())
             .map(|e| e.into_path())
-            .filter(|p| p.is_file())
+            .filter(|p| {
+                p.is_file()
+                    && matches!(
+                        p.extension().map(|e| e.to_str().unwrap()),
+                        Some("yaml") | Some("yml")
+                    )
+            })
             .map(from_filepath)
             .collect::<Result<Vec<RuleSet>>>()
     } else {

--- a/src/core/ruleset/assets/1.yaml
+++ b/src/core/ruleset/assets/1.yaml
@@ -1,0 +1,10 @@
+version: "1"
+rules:
+  - id: rule-01
+    language: go
+    message: |
+      N/A
+    pattern: |
+      :[X] && :[X]
+    rewrite: |
+      :[X]

--- a/src/core/ruleset/assets/2.yaml
+++ b/src/core/ruleset/assets/2.yaml
@@ -1,0 +1,10 @@
+version: "1"
+rules:
+  - id: rule-02
+    language: go
+    message: |
+      N/A
+    pattern: |
+      :[X] && :[X]
+    rewrite: |
+      :[X]

--- a/src/core/ruleset/assets/dumb
+++ b/src/core/ruleset/assets/dumb
@@ -1,0 +1,1 @@
+this file should not be loaded

--- a/src/core/ruleset/test.rs
+++ b/src/core/ruleset/test.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+use super::from_path;
+
+#[test]
+fn load() {
+    let mut ruleset = PathBuf::from(file!());
+    ruleset.pop();
+    ruleset.push("assets");
+
+    let ruleset = from_path(ruleset);
+    assert!(ruleset.is_ok());
+    assert_eq!(ruleset.unwrap().len(), 2);
+}


### PR DESCRIPTION
# Description

This PR changes the behaviour of rule loader. Rule loader won't try to load non-YAMLs anymore.

# Checklist

- [x] I opened a draft PR or added the `[WIP]` to the title if my PR is not ready for review.
- [x] I have reviewed the code by myself.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests enough to show how your code behaves and that your code works as expected.

# Additional Notes

N/A