### PR TITLE
Add a new constraints syntax

### DIFF
--- a/src/cli/subcommand/find.rs
+++ b/src/cli/subcommand/find.rs
@@ -3,7 +3,7 @@
 use crate::cli::encoding::{parse_encoding, LABELS_SORTED};
 use crate::cli::reporter::{ConsoleReporter, JSONReporter, Reporter, ReporterType, SARIFReporter};
 use crate::cli::{subcommand::check::handle_rulemap, CommonOpts, ReportOpts};
-use crate::core::ruleset::{self, Rule};
+use crate::core::ruleset::{self, RawPatternWithConstraints, Rule};
 use ansi_term::Color;
 use anyhow::Result;
 use encoding_rs::Encoding;
@@ -64,8 +64,10 @@ fn handle_opts(opts: FindOpts) -> Result<usize> {
         "inline".into(),
         opts.lang,
         "matched with the given rule".into(),
-        vec![opts.pattern],
-        vec![],
+        vec![RawPatternWithConstraints {
+            pattern: opts.pattern,
+            constraints: vec![],
+        }],
         opts.rewrite.map_or(vec![], |x| vec![x]),
         vec![],
     );

--- a/src/core/matcher/item.rs
+++ b/src/core/matcher/item.rs
@@ -61,52 +61,38 @@ impl<'tree> MatchedItem<'tree> {
 
     pub fn satisfies<T: Queryable + 'static>(&self, constraint: &Constraint<T>) -> Result<bool> {
         let captured_item = self.capture_of(&constraint.target);
-        match &constraint.predicate {
-            Predicate::MatchQuery(q) => {
-                if captured_item.is_none() {
-                    return Ok(false);
-                }
-                let captured_item = captured_item.unwrap();
-                match captured_item {
-                    CaptureItem::Empty => Ok(false),
-                    CaptureItem::Literal(_) => Err(anyhow::anyhow!(
-                        "match-query predicate for string literals is not supported"
-                    )),
-                    CaptureItem::Nodes(n) => Ok(n.as_vec().iter().any(|node| {
-                        let ptree = TreeView::<T>::from((*node).clone());
-                        !ptree.matches(&q.into()).count() == 0
-                    })),
-                }
-            }
-            Predicate::NotMatchQuery(q) => {
-                if captured_item.is_none() {
-                    return Ok(true);
-                }
-                let captured_item = captured_item.unwrap();
-                match captured_item {
-                    CaptureItem::Empty => Ok(true),
-                    CaptureItem::Literal(_) => Err(anyhow::anyhow!(
-                        "match-query predicate for string literals is not supported"
-                    )),
-                    CaptureItem::Nodes(n) => Ok(n.as_vec().iter().all(|node| {
-                        let ptree = TreeView::<T>::from((*node).clone());
-                        ptree.matches(&q.into()).count() == 0
-                    })),
-                }
-            }
+        if captured_item.is_none() {
+            return Err(anyhow::anyhow!(
+                "uncaptured variable was specified as constraint target: {}",
+                constraint.target.0
+            ));
+        }
+        let captured_item = captured_item.unwrap();
 
-            Predicate::MatchRegex(r) => {
-                if captured_item.is_none() {
-                    return Ok(false);
-                }
-                Ok(r.is_match(captured_item.unwrap().as_str()))
-            }
-            Predicate::NotMatchRegex(r) => {
-                if captured_item.is_none() {
-                    return Ok(true);
-                }
-                Ok(!r.is_match(captured_item.unwrap().as_str()))
-            }
+        match &constraint.predicate {
+            Predicate::MatchQuery(q) => match captured_item {
+                CaptureItem::Empty => Ok(false),
+                CaptureItem::Literal(_) => Err(anyhow::anyhow!(
+                    "match-query predicate for string literals is not supported"
+                )),
+                CaptureItem::Nodes(n) => Ok(n.as_vec().iter().any(|node| {
+                    let ptree = TreeView::<T>::from((*node).clone());
+                    !ptree.matches(&q.into()).count() == 0
+                })),
+            },
+            Predicate::NotMatchQuery(q) => match captured_item {
+                CaptureItem::Empty => Ok(true),
+                CaptureItem::Literal(_) => Err(anyhow::anyhow!(
+                    "match-query predicate for string literals is not supported"
+                )),
+                CaptureItem::Nodes(n) => Ok(n.as_vec().iter().all(|node| {
+                    let ptree = TreeView::<T>::from((*node).clone());
+                    ptree.matches(&q.into()).count() == 0
+                })),
+            },
+
+            Predicate::MatchRegex(r) => Ok(r.is_match(captured_item.as_str())),
+            Predicate::NotMatchRegex(r) => Ok(!r.is_match(captured_item.as_str())),
         }
     }
 }

--- a/src/core/transform.rs
+++ b/src/core/transform.rs
@@ -120,8 +120,8 @@ where
             .item
             .capture_of(&id)
             .map(|x| x.as_str())
+            // TODO: should be handle this None like `.ok_or(anyhow!("metavariable not found"))?;`?
             .unwrap_or_default();
-        // .ok_or(anyhow!("metavariable not found"))?;
         Ok(PatchedItem {
             body: value.into(),
             start_byte: node.start_byte(),


### PR DESCRIPTION
# Description

This PR changes the format of `patterns`. In detail, now `patterns` takes a pattern and constraints as an element. Here's an example:

```yaml
version: "1"
rules:
  - id: test
    title: test
    tags:
      - low
    language: hcl
    message: "test"
    patterns:
      - pattern: |
          a = :[ATTR]
        constraints:
          - target: ATTR
            should: not-match-regex
            pattern: "^enabled$"
```

# Checklist

- [x] I opened a draft PR or added the `[WIP]` to the title if my PR is not ready for review.
- [x] I have reviewed the code by myself.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests enough to show how your code behaves and that your code works as expected.

# Additional Notes

N/A