### PR TITLE
Add `--exclude` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +465,7 @@ dependencies = [
  "clap-verbosity-flag",
  "encoding_rs",
  "encoding_rs_io",
+ "glob",
  "itertools",
  "log",
  "pathdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ encoding_rs_io = "0.1.7"
 serde-sarif = "0.2.17"
 itertools = "0.10.1"
 pathdiff = "0.2.1"
+glob = "0.3.0"
 
 [dependencies.tree-sitter-hcl]
 path = "./third_party/tree-sitter-hcl"

--- a/src/cli/subcommand/find.rs
+++ b/src/cli/subcommand/find.rs
@@ -40,6 +40,9 @@ pub struct FindOpts {
 
     #[structopt(flatten)]
     pub report: ReportOpts,
+
+    #[structopt(long)]
+    pub exclude: Vec<String>,
 }
 
 pub fn run(opts: FindOpts) -> i32 {
@@ -81,18 +84,21 @@ fn handle_opts(opts: FindOpts) -> Result<usize> {
         ReporterType::JSON => handle_rulemap(
             JSONReporter::new(&mut stdout),
             opts.target_path,
+            opts.exclude,
             opts.encoding,
             rule_map,
         ),
         ReporterType::Console => handle_rulemap(
             ConsoleReporter::new(&mut stdout),
             opts.target_path,
+            opts.exclude,
             opts.encoding,
             rule_map,
         ),
         ReporterType::SARIF => handle_rulemap(
             SARIFReporter::new(&mut stdout),
             opts.target_path,
+            opts.exclude,
             opts.encoding,
             rule_map,
         ),

--- a/src/cli/tests/ruleset/mod.rs
+++ b/src/cli/tests/ruleset/mod.rs
@@ -30,6 +30,7 @@ macro_rules! ruleset_test {
                     encoding: encoding,
                     target_path: Some(target),
                     exit_zero: false,
+                    exclude: vec![],
                 });
                 match (r, mitem_num) {
                     (Ok(x), Ok(y)) if x == y => (),


### PR DESCRIPTION
# Description

This PR adds `--exclude` flag to `shisho check` and `shisho find`, which can be used to ignore files as follows:

```
shisho check [<opts>] --exclude "foo/*" --exclude "vendor/*" --exclude "node_modules/**"
```

This closes #94.

# Checklist

- [x] I opened a draft PR or added the `[WIP]` to the title if my PR is not ready for review.
- [x] I have reviewed the code by myself.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests enough to show how your code behaves and that your code works as expected.

# Additional Notes

N/A