### PR TITLE
feat: shared constraints

### DIFF
--- a/src/cli/tests/ruleset/generic/mod.rs
+++ b/src/cli/tests/ruleset/generic/mod.rs
@@ -46,5 +46,10 @@ mod tests {
             ("mixed-pattern-like.yaml", "unmatch.tf", Result::Err(anyhow::anyhow!("")), None),
             ("no-pattern-like.yaml", "unmatch.tf", Result::Err(anyhow::anyhow!("")), None),
         ],
+        shared_constraints: [
+            ("ruleset.yaml", "test.Dockerfile", Result::Ok(8), None),
+            ("ruleset.yaml", "dockerfile", Result::Ok(8), None),
+            ("ruleset.yaml", "Dockerfile.test", Result::Ok(8), None),
+        ],
     }
 }

--- a/src/cli/tests/ruleset/generic/shared_constraints/Dockerfile.test
+++ b/src/cli/tests/ruleset/generic/shared_constraints/Dockerfile.test
@@ -1,0 +1,19 @@
+FROM test
+FROM test as alias1
+FROM foo
+FROM foo as alias2
+
+FROM test:tag
+FROM test:tag as alias3
+FROM foo:tag
+FROM foo:tag as alias4
+
+FROM test@hash
+FROM test@hash as alias5
+FROM foo@hash
+FROM foo@hash as alias6
+
+FROM test:tag@hash
+FROM test:tag@hash as alias7
+FROM foo:tag@hash
+FROM foo:tag@hash as alias8

--- a/src/cli/tests/ruleset/generic/shared_constraints/dockerfile
+++ b/src/cli/tests/ruleset/generic/shared_constraints/dockerfile
@@ -1,0 +1,19 @@
+FROM test
+FROM test as alias1
+FROM foo
+FROM foo as alias2
+
+FROM test:tag
+FROM test:tag as alias3
+FROM foo:tag
+FROM foo:tag as alias4
+
+FROM test@hash
+FROM test@hash as alias5
+FROM foo@hash
+FROM foo@hash as alias6
+
+FROM test:tag@hash
+FROM test:tag@hash as alias7
+FROM foo:tag@hash
+FROM foo:tag@hash as alias8

--- a/src/cli/tests/ruleset/generic/shared_constraints/ruleset.yaml
+++ b/src/cli/tests/ruleset/generic/shared_constraints/ruleset.yaml
@@ -1,0 +1,20 @@
+version: "1"
+rules:
+  - id: "use-trusted-base-images"
+    language: dockerfile
+    message: |
+      Use trusted base images if possible.
+    patterns:
+      - pattern: FROM :[NAME]
+      - pattern: FROM :[NAME] AS :[ALIAS]
+      - pattern: FROM :[NAME]@:[HASH]
+      - pattern: FROM :[NAME]@:[HASH] AS :[ALIAS]
+      - pattern: FROM :[NAME]::[TAG]
+      - pattern: FROM :[NAME]::[TAG] AS :[ALIAS]
+      - pattern: FROM :[NAME]::[TAG]@:[HASH]
+      - pattern: FROM :[NAME]::[TAG]@:[HASH] AS :[ALIAS]
+    constraints:
+      - target: NAME
+        should: be-any-of
+        strings:
+          - test

--- a/src/cli/tests/ruleset/generic/shared_constraints/test.Dockerfile
+++ b/src/cli/tests/ruleset/generic/shared_constraints/test.Dockerfile
@@ -1,0 +1,19 @@
+FROM test
+FROM test as alias1
+FROM foo
+FROM foo as alias2
+
+FROM test:tag
+FROM test:tag as alias3
+FROM foo:tag
+FROM foo:tag as alias4
+
+FROM test@hash
+FROM test@hash as alias5
+FROM foo@hash
+FROM foo@hash as alias6
+
+FROM test:tag@hash
+FROM test:tag@hash as alias7
+FROM foo:tag@hash
+FROM foo:tag@hash as alias8

--- a/src/core/ruleset.rs
+++ b/src/core/ruleset.rs
@@ -65,12 +65,12 @@ impl Rule {
             title: None,
 
             patterns,
+            constraints: vec![],
             rewrite_options,
             tags,
 
             // these params are just for YAMLs
             pattern: None,
-            constraints: vec![],
             rewrite: None,
         }
     }
@@ -101,7 +101,13 @@ impl Rule {
                 pattern: p.to_string(),
                 constraints: self.constraints.clone(),
             }]),
-            (None, patterns) if !patterns.is_empty() => Ok(patterns.clone()),
+            (None, patterns) if !patterns.is_empty() => Ok(patterns
+                .into_iter()
+                .map(|p| RawPatternWithConstraints {
+                    pattern: p.pattern.to_string(),
+                    constraints: [p.constraints.clone(), self.constraints.clone()].concat(),
+                })
+                .collect()),
             _ => Err(anyhow::anyhow!(
                 "You can use only one of `pattern` or `patterns`."
             )),
@@ -181,7 +187,13 @@ impl RawConstraint {
                 pattern: p.to_string(),
                 constraints: self.constraints.clone(),
             }]),
-            (None, patterns) if !patterns.is_empty() => Ok(patterns.clone()),
+            (None, patterns) if !patterns.is_empty() => Ok(patterns
+                .into_iter()
+                .map(|p| RawPatternWithConstraints {
+                    pattern: p.pattern.to_string(),
+                    constraints: [p.constraints.clone(), self.constraints.clone()].concat(),
+                })
+                .collect()),
             (None, patterns) if patterns.is_empty() => Ok(vec![]),
             _ => Err(anyhow::anyhow!(
                 "You can use only one of `pattern` or `patterns`."

--- a/src/core/target.rs
+++ b/src/core/target.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use encoding_rs::Encoding;
 use encoding_rs_io::DecodeReaderBytesBuilder;
+use itertools::Itertools;
 use pathdiff::diff_paths;
 use std::{
     env,
@@ -167,11 +168,21 @@ impl Target {
         }?;
 
         match ext.to_str() {
-            Some("go") => Some(Language::Go),
-            Some("tf") => Some(Language::HCL),
-            Some("Dockerfile") => Some(Language::Dockerfile),
-            _ => None,
+            Some("go") => return Some(Language::Go),
+            Some("tf") => return Some(Language::HCL),
+            _ => (),
+        };
+
+        if p.file_name()?
+            .to_ascii_lowercase()
+            .to_str()?
+            .split('.')
+            .contains(&"dockerfile")
+        {
+            return Some(Language::Dockerfile);
         }
+
+        return None;
     }
 }
 


### PR DESCRIPTION
# Description

This PR adds a concept of shared constraints.

A shared constraint is a kind of constraint that is shared among multiple patterns. For instance, in the following rule, a constraint with `target: NAME` behaves as if they are placed inside each pattern in `patterns`:

```yaml
version: "1"
rules:
  - id: "use-trusted-base-images"
    language: dockerfile
    message: |
      Use trusted base images if possible.
    patterns:
      - pattern: FROM :[NAME]
      - pattern: FROM :[NAME] AS :[ALIAS]
      - pattern: FROM :[NAME]@:[HASH]
      - pattern: FROM :[NAME]@:[HASH] AS :[ALIAS]
      - pattern: FROM :[NAME]::[TAG]
      - pattern: FROM :[NAME]::[TAG] AS :[ALIAS]
      - pattern: FROM :[NAME]::[TAG]@:[HASH]
      - pattern: FROM :[NAME]::[TAG]@:[HASH] AS :[ALIAS]
    constraints:
      - target: NAME
        should: be-any-of
        strings:
          - test
          - foo
```

# Checklist

- [x] I opened a draft PR or added the `[WIP]` to the title if my PR is not ready for review.
- [x] I have reviewed the code by myself.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests enough to show how your code behaves and that your code works as expected.

# Additional Notes

N/A