### PR TITLE
Add missing argument for clone in documentation

### DIFF
--- a/docs/content/shisho/getting-started.md
+++ b/docs/content/shisho/getting-started.md
@@ -80,7 +80,7 @@ shisho --help
 If you're a Rust developer, you can use `cargo` to install Shisho locally:
 
 ```sh
-git clone git@github.com:flatt-security/shisho.git
+git clone --recurse-submodules git@github.com:flatt-security/shisho.git
 cd shisho
 cargo install --path .
 ```


### PR DESCRIPTION
Following the documentation and building from source will fail when dependencies in [`third_party`](https://github.com/flatt-security/shisho/tree/506db3538029cc6233e0a10716972b7204ba1475/third_party) directory are missing.

